### PR TITLE
bt/pro-270-handle-registration-step-redirections

### DIFF
--- a/src/app/components/RegistrationStep1/index.tsx
+++ b/src/app/components/RegistrationStep1/index.tsx
@@ -17,11 +17,17 @@ import { ArrowRightIcon } from '@/app/icons/ArrowRightIcon';
 import { registrationData } from '@/core/registrationData';
 import styles from './styles.module.css';
 import { CopyTextToolbarButton } from '../CopyTextToolbarButton';
+import { useRegistrationProgressContext } from '@/app/providers/RegistrationProgressProvider';
 
 export function RegistrationStep1() {
   const [isSeedPhraseVisible, setIsSeedPhraseVisible] = useState(false);
   const router = useRouter();
   const { seedPhrase, clearSensitiveState } = useSensitiveState();
+  const { setIsRegistrationInProgress } = useRegistrationProgressContext();
+
+  useEffect(() => {
+    setIsRegistrationInProgress(true);
+  }, [setIsRegistrationInProgress]);
 
   const copySeedPhrase = useCallback(() => {
     navigator.clipboard.writeText(seedPhrase);

--- a/src/app/components/RegistrationStep2/index.tsx
+++ b/src/app/components/RegistrationStep2/index.tsx
@@ -14,6 +14,7 @@ import { Warning } from '@/app/components/Warning';
 import { registrationData } from '@/core/registrationData';
 import styles from './styles.module.css';
 import { RegistrationFooterActions } from '../RegistrationFooterActions';
+import { useProtectRegistrationRouteAccess } from '@/app/hooks/useProtectRegistrationRouteAccess';
 
 export const RegistrationStep2 = () => {
   const router = useRouter();
@@ -26,6 +27,8 @@ export const RegistrationStep2 = () => {
     clearSelectedSeedWords,
     clearSensitiveState
   } = useSensitiveState();
+
+  useProtectRegistrationRouteAccess();
 
   const selectionCompleted =
     shuffledSeedWords.length > 0 &&

--- a/src/app/components/RegistrationStep3/index.tsx
+++ b/src/app/components/RegistrationStep3/index.tsx
@@ -18,6 +18,7 @@ import { SquarePenIcon } from '@/app/icons/SquarePenIcon';
 import { RegistrationFooterActions } from '../RegistrationFooterActions';
 import { CopyTextToolbarButton } from '../CopyTextToolbarButton';
 import styles from './styles.module.css';
+import { useProtectRegistrationRouteAccess } from '@/app/hooks/useProtectRegistrationRouteAccess';
 
 export function RegistrationStep3() {
   const router = useRouter();
@@ -36,6 +37,8 @@ export function RegistrationStep3() {
   const [isFailedAttempt, setIsFailedAttempt] = useState(false);
   const [autoFocusBitcoinAddressField, setAutoFocusBitcoinAddressField] =
     useState(false);
+
+  useProtectRegistrationRouteAccess();
 
   const isBitcoinAddressPopulated = bitcoinAddress.length > 0;
   const isSignaturePopulated = signature.length > 0;

--- a/src/app/hooks/useProtectRegistrationRouteAccess.ts
+++ b/src/app/hooks/useProtectRegistrationRouteAccess.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useRegistrationProgressContext } from '@/app/providers/RegistrationProgressProvider';
+import { useRouter } from 'next/navigation';
+
+export const useProtectRegistrationRouteAccess = () => {
+  const { isRegistrationInProgress } = useRegistrationProgressContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isRegistrationInProgress) {
+      router.replace('/');
+    }
+  }, [router, isRegistrationInProgress]);
+};

--- a/src/app/providers/RegistrationProgressProvider/index.tsx
+++ b/src/app/providers/RegistrationProgressProvider/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { createContext, useContext, useState } from 'react';
+
+type RegistrationProgressContextType = {
+  isRegistrationInProgress: boolean;
+  setIsRegistrationInProgress: (value: boolean) => void;
+};
+
+const RegistrationProgressContext = createContext<
+  RegistrationProgressContextType | undefined
+>(undefined);
+
+export const RegistrationProgressProvider = ({
+  children
+}: {
+  children: React.ReactNode;
+}) => {
+  const [isRegistrationInProgress, setIsRegistrationInProgress] =
+    useState(false);
+
+  return (
+    <RegistrationProgressContext.Provider
+      value={{ isRegistrationInProgress, setIsRegistrationInProgress }}
+    >
+      {children}
+    </RegistrationProgressContext.Provider>
+  );
+};
+
+export const useRegistrationProgressContext = () => {
+  const context = useContext(RegistrationProgressContext);
+  if (!context) {
+    throw new Error(
+      'useRegistrationProgressContext must be used within a RegistrationProgressProvider'
+    );
+  }
+  return context;
+};

--- a/src/app/register/layout.tsx
+++ b/src/app/register/layout.tsx
@@ -1,0 +1,11 @@
+import { RegistrationProgressProvider } from '@/app/providers/RegistrationProgressProvider';
+
+export default function RegisterLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <RegistrationProgressProvider>{children}</RegistrationProgressProvider>
+  );
+}


### PR DESCRIPTION
# Why
We need to prevent direct access to steps 2 and 3.

# How
- Use context to persist progress state across registration steps
- Use the progress state to redirect the user to the homepage if they have not started the registration flow