### PR TITLE
bt/pro-339-update-step-2-to-use-word-indices

### DIFF
--- a/src/app/components/RegistrationStep2/index.tsx
+++ b/src/app/components/RegistrationStep2/index.tsx
@@ -189,9 +189,13 @@ const useSensitiveState = () => {
   }, [seedPhrase, clearSensitiveState]);
 
   const addSelectedSeedWordIndex = useCallback(
-    (index: number) =>
-      setSelectedSeedWordIndices(current => [...current, index]),
-    []
+    (index: number) => {
+      // guard against adding duplicate indices
+      if (!selectedSeedWordIndices.includes(index)) {
+        setSelectedSeedWordIndices(current => [...current, index]);
+      }
+    },
+    [selectedSeedWordIndices]
   );
 
   const clearSelectedSeedWordIndices = useCallback(


### PR DESCRIPTION
# Why
- The seed phrase confirmation UI needs to handle seed phrases that contain multiple instances of the same word.

# How
- Updated step 2 to track the index of each selected seed word instead of its value.