### PR TITLE
bt/pro-359-add-changelog-page

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { releases } from '@/data/changelog';
+import styles from './styles.module.css';
+
+export const metadata: Metadata = {
+  title: 'Changelog'
+};
+
+export default function ChangelogPage() {
+  if (releases.length < 1) {
+    notFound();
+  }
+
+  return (
+    <main className={styles.main}>
+      <Link href='/'>yellowpages.xyz</Link>
+      <h1 className={styles.title}>Changelog</h1>
+      <div className={styles.content}>
+        {releases.map(item => (
+          <div key={item.version} className={styles.release}>
+            <h2 className={styles.releaseHeading}>
+              Version: <span>{item.version}</span>
+            </h2>
+            <h3 className={styles.releaseHeading}>
+              Release date: <span>{item.releaseDate}</span>
+            </h3>
+            <div className={styles.releaseChanges}>
+              <h3 className={styles.releaseHeading}>Changes:</h3>
+              <ul>
+                {item.changes.map(change => (
+                  <li key={change}>{change}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/changelog/styles.module.css
+++ b/src/app/changelog/styles.module.css
@@ -1,0 +1,53 @@
+.main {
+    padding-top: 20px;
+}
+
+.title {
+    font-size: 1.4rem;
+    letter-spacing: -1px;
+    font-weight: 400;
+    line-height: 2.2rem;
+    margin-bottom: 0;
+    margin-top: 24px;
+}
+
+.content {
+    width: 100%;
+    padding-bottom: 60px;
+}
+
+.release {
+    margin-bottom: 28px;
+    margin-top: 28px;
+    padding-top: 28px;
+    border-top: 1px dashed #aca165;
+    width: 100%;
+}
+
+.releaseHeading {
+    font-size: 1rem;
+    margin-bottom: 0;
+    margin-top: 10px;
+}
+
+.releaseHeading span {
+    font-weight: 400;
+}
+
+.releaseChanges {
+    margin-top: 20px;
+}
+
+.releaseChanges ul {
+    margin-top: 10px;
+    padding-left: 16px;
+    line-height: 1.75rem;
+}
+
+@media only screen and (min-width: 768px) {
+    .title {
+        margin-top: 32px;
+        font-size: 1.8rem;
+        margin-bottom: 16px;
+    }
+}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,0 +1,5 @@
+export const releases: Array<{
+  version: string;
+  releaseDate: string;
+  changes: Array<string>;
+}> = [];


### PR DESCRIPTION
# Why
- We want to display a changelog.

# How
- Added new `/changelog` route along with changelog data file.
