### PR TITLE
Send proofrequests over websockets

### DIFF
--- a/src/app/components/RegistrationStep3/index.tsx
+++ b/src/app/components/RegistrationStep3/index.tsx
@@ -135,8 +135,7 @@ export function RegistrationStep3() {
         await searchYellowpagesByBtcAddress(bitcoinAddress);
 
         router.push('/registration-complete');
-      } catch (error) {
-        console.error('Registration failed:', error);
+      } catch {
         setShowFailedRequestAlert(true);
         setIsSubmitting(false);
       }

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -280,8 +280,6 @@ function setupWebSocketErrorHandlers(ws: WebSocket) {
         errorMessage = `Server encountered an internal error (code ${WebSocketCloseCode.InternalError})`;
       } else if (event.code === WebSocketCloseCode.Timeout) {
         errorMessage = `Operation timed out on server (code ${WebSocketCloseCode.Timeout})`;
-      } else {
-        errorMessage = `Connection closed unexpectedly: code ${event.code}`;
       }
 
       const error = new Error(errorMessage);


### PR DESCRIPTION
# Why
- The proof service now expects requests over websockets, so we can progress to doing an ML-KEM+AES handshake

# How
- Switched proof service URL to `wss`
- Set up a websocket connection to the URL
- Added error handling on the websocket using an `AbortController`, so we can abort whenever there is a network error, or whenever an error code close frame is received from the server
- Added a `raceWithTimeout` function so we can have a 30 second timeout every time we need to wait for a message / confirmation from the user
- Ensured everything is cleaned up properly to avoid memory leaks of dangling listeners
- Noticed we don't currently have a way of seeing what error the user experienced during registration, so added a console.error to the registration page catch block

# Security / Environment Variables (if applicable)
- N/A

# Testing
- Did end-to-end tests against local proof service:
  - Tested happy path succeeds
  - Added long waits to the server to validate that the client would time out properly
- Once the proof service is deployed, our end-to-end tests will run as usual, and should succeed