### PR TITLE
expect first located element to be visible

### DIFF
--- a/src/__tests__/e2e/registration.e2e.test.ts
+++ b/src/__tests__/e2e/registration.e2e.test.ts
@@ -295,11 +295,13 @@ test('unsuccessful registration attempt when the order of the seed phrase select
 
   // ensure the seed words can be selected
   await expect(
-    page.getByRole('button', {
-      name: seedWords[0],
-      exact: true,
-      disabled: false
-    })
+    page
+      .getByRole('button', {
+        name: seedWords[0],
+        exact: true,
+        disabled: false
+      })
+      .first()
   ).toBeVisible();
 });
 


### PR DESCRIPTION
This ensures it finds the first instance of a word.