### PR TITLE
CI fix: P11-02-002 WP3: Lack of commit pinning in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: lts/*
 
@@ -42,7 +42,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: Checkout Repo (development)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # use development branch for testing
           ref: development
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: lts/*
 
@@ -44,7 +44,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
# Why
"""
During the review of GitHub Actions workflows across all repositories, it was found that third-party actions were pinned to a version tag and not a specific commit. While pinning by version tag is a common practice, using the full commit SHA provides additional protection against supply chain attacks, as it directly references a unique point in the
Git history.
Affected file:
yellowpages-data-layer-service/.github/workflows/deploy_prod.yml
Affected code:
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
- name: Configure AWS credentials
  uses: aws-actions/configure-aws-credentials@v4
"""

# How
"While the third-party actions present in the analyzed workflows are maintained by established actors, it is recommended to consider introducing commit pinning as an additional defense-in-depth measure against potential supply chain attacks."
- For every instance of `uses:` in the repo, I checked the releases for the relevant Action, and copied over the commit of the latest release.
  - https://github.com/actions/checkout/releases/tag/v4.2.2
  - https://github.com/actions/setup-node/releases/tag/v4.4.0
  - https://github.com/actions/upload-artifact/releases/tag/v4.6.2

# Security / Environment Variables (if applicable)
- Fixes P11-02-002 WP3: Lack of commit pinning in GitHub Actions

# Testing
- CI on this PR should succeed
