### PR TITLE
CI fix: P11-02-001 WP3: Command injection in GitHub Actions

### DIFF
--- a/.github/workflows/restrict_pr_branches.yml
+++ b/.github/workflows/restrict_pr_branches.yml
@@ -10,12 +10,13 @@ jobs:
     name: Restrict PRs into main
     runs-on: ubuntu-latest
 
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+
     steps:
       - name: Check source branch
         run: |
-          echo "Base branch: ${{ github.base_ref }}"
-          echo "Head branch: ${{ github.head_ref }}"
-          if [ "${{ github.head_ref }}" != "development" ]; then
+          if [[ "$HEAD_REF" != "development" ]]; then
             echo "❌ Pull requests into 'main' must come from 'development'."
             exit 1
           fi


### PR DESCRIPTION
# Why
"""
While reviewing GitHub Actions workflows, it was discovered that the restrict_pr_branches workflow, present in the service and client repositories, is vulnerable to script injection attacks. Specifically, the workflow directly interpolates the github.head_ref context variable into shell commands without proper escaping. As this variable is used for the name of the branch of the originating pull request, which can contain special characters, substituting it directly into the script allows to inject arbitrary shell commands which will be executed by the GitHub Actions runner.
Affected file:
.github/workflows/restrict_pr_branches.yml
Affected code:
```
steps:
  - name: Check source branch
    run: |
      echo "Base branch: ${{ github.base_ref }}"
      echo "Head branch: ${{ github.head_ref }}"
      if [ "${{ github.head_ref }}" != "development" ]; then
        echo ":x: Pull requests into 'main' must come from 'development'."
        exit 1
      fi
```
This could be exploited by a user with a permission to submit pull requests to the GitHub repository. For example, naming the source branch ";{cat,/etc/passwd};" will cause the string to break out of the echo statement and be interpreted as code.
While the impact of command injection in this scenario is limited, as the attacker would already have to have some kind of access to the private repository, it should still be fixed to prevent any potential escalation of privileges and to guard against future changes in repository permissions or unforeseen attack vectors.
"""

# How
"To mitigate this vulnerability, it is recommended to use intermediate environment variables to pass values to inline shell scripts for all variables with potentially untrusted input."
- The branch head ref is now put into an environment variable before being used in the script.

# Security / Environment Variables (if applicable)
- Fixes `P11-02-001 WP3: Command injection in GitHub Actions`

# Testing
- Checked that the action will still fail if a pull request is opened from a non-development branch into main
https://github.com/p-11/yellowpages-verification-service/actions/runs/15561156285
