### PR TITLE
bt/pro-477-p11-02-004-wp1-lack-of-cross-origin-related-http-security

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,27 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/(.*)', // Apply to all routes
+        headers: [
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'same-origin'
+          },
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin'
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy',
+            value: 'require-corp'
+          }
+        ]
+      }
+    ];
+  }
 };
 
 export default nextConfig;


### PR DESCRIPTION
# Why
- We want to ensure all routes include cross-origin-infoleak-related HTTP security headers.

# How
- Updated `next.config.ts` to included the strictest values for `Cross-Origin-Resource-Policy`, `Cross-Origin-Opener-Policy`, and `Cross-Origin-Embedder-Policy`.

# Security
- Fixes P11-02-004 WP1
