### PR TITLE
bt/pro-500-remove-status-badge-from-homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,13 +50,6 @@ export default function HomePage() {
               Project Eleven
             </Link>
           </p>
-          <iframe
-            src='https://status.projecteleven.com/badge?theme=light'
-            width='250'
-            height='30'
-            scrolling='no'
-            style={{ colorScheme: 'normal', border: 0 }}
-          />
         </div>
       )}
     </main>


### PR DESCRIPTION
# Why
- We want to temporarily remove the status indicator until the status page's headers include the correct `cross-origin-resource-policy` header value.

# How
- Removed the status indicator on the homepage.

# Security / Environment Variables (if applicable)
N/A

# Testing
- Tested locally.
