### PR TITLE
bt/pro-512-show-aborted-websocket-error-codes

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -369,7 +369,7 @@ function setupWebSocketErrorHandlers(ws: WebSocket) {
     customMessage: string
   ) => {
     const abortHandler = () => {
-      reject(new ErrorWithCode(signal.reason ?? customMessage, 'YP-007'));
+      reject(signal.reason || new ErrorWithCode(customMessage, 'YP-007'));
     };
     signal.addEventListener('abort', abortHandler, { once: true });
     return () => signal.removeEventListener('abort', abortHandler);


### PR DESCRIPTION
# Why
- We want to show aborted websocket error codes.

# How
- Updated abort handler to include the `signal.reason`.

# Security / Environment Variables (if applicable)
N/A

# Testing
- Tested on a local development build.
