### PR TITLE
add websocket logging to e2e tests

### DIFF
--- a/src/__tests__/e2e/registration.e2e.test.ts
+++ b/src/__tests__/e2e/registration.e2e.test.ts
@@ -5,6 +5,8 @@ import * as bitcoin from 'bitcoinjs-lib';
 import { HDKey } from '@scure/bip32';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
+/* eslint no-console: "off" */
+
 const generateBtcWallet = () => {
   const mnemonic = generateMnemonic(wordlist, 256);
   const seed = mnemonicToSeedSync(mnemonic);
@@ -64,6 +66,13 @@ test('successful registration and search result', async ({
   page
 }, testInfo) => {
   testInfo.setTimeout(60000);
+  page.on('websocket', ws => {
+    console.log(`WebSocket opened: ${ws.url()}>`);
+    ws.on('framesent', event => console.log(event.payload));
+    ws.on('framereceived', event => console.log(event.payload));
+    ws.on('socketerror', event => console.log(event));
+    ws.on('close', () => console.log('WebSocket closed'));
+  });
 
   const btcWallet = generateBtcWallet();
 
@@ -133,6 +142,13 @@ test('successful registration when the Bitcoin address is changed', async ({
   page
 }, testInfo) => {
   testInfo.setTimeout(60000);
+  page.on('websocket', ws => {
+    console.log(`WebSocket opened: ${ws.url()}>`);
+    ws.on('framesent', event => console.log(event.payload));
+    ws.on('framereceived', event => console.log(event.payload));
+    ws.on('socketerror', event => console.log(event));
+    ws.on('close', () => console.log('WebSocket closed'));
+  });
 
   const btcWallet = generateBtcWallet();
   const btcWallet2 = generateBtcWallet();


### PR DESCRIPTION
# Why
- We want to log websocket errors in e2e tests.

# How
- Added logs using Playwright's websocket class (https://playwright.dev/docs/api/class-websocket).

# Security / Environment Variables (if applicable)
N/A

# Testing
- Tested on local test environment.