### PR TITLE
remove footer separator character

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
               Project Eleven
             </Link>
           </p>
-          <span className={styles.footerSeparator}>|</span>
+          <span className={styles.footerSeparator} />
           <p>
             <Link href='https://status.projecteleven.com' target='_blank'>
               System status


### PR DESCRIPTION
# Why
- We want to remove the duplicate footer separator.

# How
- Removed the separator character (the element's styling renders it instead).

# Security / Environment Variables (if applicable)
N/A

# Testing
Tested on local development environment.
