### PR TITLE
bt/pro-573-conditionally-include-frame-src-directive

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,12 +13,21 @@ const scriptSrcDirective = [
   .filter(Boolean)
   .join(' ');
 
+const frameSrcDirective = [
+  'https://status.projecteleven.com',
+  process.env.BOT_PROTECTION_ENABLED === 'true'
+    ? null
+    : 'https://challenges.cloudflare.com'
+]
+  .filter(Boolean)
+  .join(' ');
+
 const contentSecurityPolicy = `
 default-src 'self';
 connect-src 'self' ${domains.proofService} ${domains.verificationService};
 script-src ${scriptSrcDirective};
 style-src 'self' 'unsafe-inline';
-frame-src https://challenges.cloudflare.com https://status.projecteleven.com;
+frame-src ${frameSrcDirective};
 img-src 'self';
 font-src 'self';
 object-src 'none';


### PR DESCRIPTION
# Why
We want to remove the Cloudflare domain from the frame-src content security policy directive the bot protection is enabled.

# How
- Updated content security policy header

# Security / Environment Variables (if applicable)
N/A

# Testing
Tested on local development and test environment.
