### PR TITLE
Add info about bot prevention tools to FAQ

### DIFF
--- a/src/app/faqs/page.tsx
+++ b/src/app/faqs/page.tsx
@@ -264,9 +264,10 @@ export default function FaqsPage() {
             The proof only exposes two items: your Bitcoin address (already
             public once you transact) and your new post-quantum addresses (which
             reveals nothing about balances). It does not publish the signatures,
-            verification keys, IP data or any personal identifiers. We
-            don&apos;t log or store any client IP addresses, but as an extra
-            precaution you could opt to use a VPN during registration.
+            verification keys, IP data or any personal identifiers. We use
+            third-party bot prevention tools that temporarily store client IP
+            addresses for analytics, discarding them after a short period. As an
+            extra precaution you could opt to use a VPN during registration.
           </p>
         </AccordionItem>
         <AccordionItem title='How are the proofs stored and who can see them?'>


### PR DESCRIPTION
# Why
- Third-party bot prevention tools we're using store client IP addresses temporarily for analytics, so we should provide info about that.

# How
- Update FAQ about information revealed during registration.

# Security / Environment Variables (if applicable)
- N/A

# Testing
- Ran it locally
