### PR TITLE
replace support@ emails with contact us link

### DIFF
--- a/src/app/components/RegistrationStep3/index.tsx
+++ b/src/app/components/RegistrationStep3/index.tsx
@@ -415,13 +415,15 @@ export function RegistrationStep3() {
             <DialogDescription>{errorMessage}</DialogDescription>
           )}
           <Alert>
-            If the error persists, please reach out to{' '}
+            If the error persists, please{' '}
             <a
-              href='mailto:support@projecteleven.com'
+              href='https://www.projecteleven.com/contact'
+              target='_blank'
               className={styles.contactLink}
             >
-              support@projecteleven.com
+              contact us
             </a>
+            .
             {errorCode && (
               <span className={styles.errorCode}>Error code: {errorCode}</span>
             )}

--- a/src/app/faqs/page.tsx
+++ b/src/app/faqs/page.tsx
@@ -310,10 +310,11 @@ export default function FaqsPage() {
         <h2>6. Support &amp; Feedback</h2>
         <AccordionItem title='Found a bug or got feedback?'>
           <p>
-            Please email{' '}
-            <a href='mailto:support@projecteleven.com'>
-              support@projecteleven.com
+            Please{' '}
+            <a href='https://www.projecteleven.com/contact' target='_blank'>
+              contact us
             </a>
+            .
           </p>
         </AccordionItem>
       </div>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -26,13 +26,15 @@ export default function GlobalError() {
           <p>Please refresh your browser and try again.</p>
           <div className={styles.alertSection}>
             <Alert>
-              If the error persists, please reach out to{' '}
+              If the error persists, please{' '}
               <a
-                href='mailto:support@projecteleven.com'
+                href='https://www.projecteleven.com/contact'
+                target='_blank'
                 className={styles.contactLink}
               >
-                support@projecteleven.com
+                contact us
               </a>
+              .
             </Alert>
           </div>
         </main>


### PR DESCRIPTION
# Why
- We want to replace support@ email links with a link to Project Eleven's contact page.

# How
- Replaced all instances of the support@ email to point to the contact page.

# Security / Environment Variables (if applicable)
N/A

# Testing
- Tested on a local development environment.